### PR TITLE
Do not publish .idea/ folder to NPM registry

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,9 @@
 /test/
 /src/
 /lib/csv.min.js
+.idea
+.vscode
+.history
 .git
 .gitignore
 .eslintrc


### PR DESCRIPTION
Currently, the `.idea` folder is published to the NPM registry. See here: https://unpkg.com/browse/csv.js@1.0.7/.idea/

I'd recommend merging this PR and publish v1.0.8.